### PR TITLE
Add default scenario handling and scenario rule endpoint

### DIFF
--- a/finance_planner/regular_operations/serializers.py
+++ b/finance_planner/regular_operations/serializers.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias
 
 from django.db import transaction
 from regular_operations.models import RegularOperation, RegularOperationType
 from rest_framework import serializers
 from scenarios.models import PaymentScenario, RuleType, ScenarioRule
+
+
+Empty: TypeAlias = type(serializers.empty)
+ScenarioRulePayload: TypeAlias = Mapping[str, Any]
+ScenarioRulesData: TypeAlias = Sequence[ScenarioRulePayload] | None | Empty
+ScenarioMetaData: TypeAlias = Mapping[str, Any] | None | Empty
 
 
 class RegularOperationScenarioRuleReadSerializer(serializers.ModelSerializer):
@@ -128,7 +135,7 @@ class RegularOperationCreateUpdateSerializer(serializers.ModelSerializer):
         start_date = attrs.get("start_date") or (instance.start_date if instance else None)
         end_date = attrs.get("end_date") or (instance.end_date if instance else None)
         scenario_rules = attrs.get("scenario_rules")
-        scenario_meta = attrs.get("scenario", serializers.empty)
+        scenario_data = attrs.get("scenario", serializers.empty)
 
         if instance and "type" in attrs and attrs["type"] != instance.type:
             raise serializers.ValidationError({"type": "Нельзя менять тип операции"})
@@ -148,7 +155,7 @@ class RegularOperationCreateUpdateSerializer(serializers.ModelSerializer):
                 from_account=from_account,
                 to_account=to_account,
                 scenario_rules=scenario_rules,
-                scenario_meta=scenario_meta,
+                scenario_data=scenario_data,
             )
         elif operation_type == RegularOperationType.INCOME:
             self._validate_income(
@@ -199,8 +206,8 @@ class RegularOperationCreateUpdateSerializer(serializers.ModelSerializer):
         *,
         from_account: Any,
         to_account: Any,
-        scenario_rules: Any,
-        scenario_meta: Any,
+        scenario_rules: ScenarioRulesData,
+        scenario_data: ScenarioMetaData,
     ) -> None:
         if from_account is None:
             raise serializers.ValidationError(
@@ -210,11 +217,11 @@ class RegularOperationCreateUpdateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 {"to_account": "Для расходной операции не нужно указывать счет зачисления"}
             )
-        if scenario_rules:
+        if scenario_rules not in (None, serializers.empty) and len(scenario_rules) > 0:
             raise serializers.ValidationError(
                 {"scenario_rules": "Правила сценария доступны только для доходных операций"}
             )
-        if scenario_meta is not serializers.empty and scenario_meta is not None:
+        if scenario_data is not serializers.empty and scenario_data is not None:
             raise serializers.ValidationError(
                 {"scenario": "Сценарий доступен только для доходных операций"}
             )
@@ -228,40 +235,40 @@ class RegularOperationCreateUpdateSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data: dict[str, Any]) -> RegularOperation:
         scenario_rules = validated_data.pop("scenario_rules", [])
-        scenario_meta = validated_data.pop("scenario", serializers.empty)
+        scenario_data = validated_data.pop("scenario", serializers.empty)
         with transaction.atomic():
             operation = RegularOperation.objects.create(**validated_data)
-            self._sync_scenario(operation, scenario_rules, scenario_meta)
+            self._sync_scenario(operation, scenario_rules, scenario_data)
         return operation
 
     def update(
         self, instance: RegularOperation, validated_data: dict[str, Any]
     ) -> RegularOperation:
         scenario_rules = validated_data.pop("scenario_rules", serializers.empty)
-        scenario_meta = validated_data.pop("scenario", serializers.empty)
+        scenario_data = validated_data.pop("scenario", serializers.empty)
         with transaction.atomic():
             operation = super().update(instance, validated_data)
-            self._sync_scenario(operation, scenario_rules, scenario_meta)
+            self._sync_scenario(operation, scenario_rules, scenario_data)
         return operation
 
     def _sync_scenario(
         self,
         operation: RegularOperation,
-        scenario_rules: Any,
-        scenario_meta: Any,
+        scenario_rules: ScenarioRulesData,
+        scenario_data: ScenarioMetaData,
     ) -> None:
-        scenario_meta_provided = scenario_meta is not serializers.empty
+        scenario_data_provided = scenario_data is not serializers.empty
         scenario_defaults = {
             "title": operation.title,
             "description": operation.description,
             "is_active": operation.is_active,
         }
-        scenario_meta_payload = (
-            scenario_meta
-            if scenario_meta_provided and scenario_meta is not None
+        scenario_data_payload = (
+            scenario_data
+            if scenario_data_provided and scenario_data is not None
             else {}
         )
-        scenario_creation_values = {**scenario_defaults, **scenario_meta_payload}
+        scenario_creation_values = {**scenario_defaults, **scenario_data_payload}
 
         if operation.type == RegularOperationType.INCOME:
             scenario = getattr(operation, "scenario", None)
@@ -271,33 +278,34 @@ class RegularOperationCreateUpdateSerializer(serializers.ModelSerializer):
                     operation=operation,
                     **scenario_creation_values,
                 )
-            elif scenario_meta_provided:
+            elif scenario_data_provided:
                 fields_to_update: list[str] = []
-                if "title" in scenario_meta_payload:
-                    scenario.title = scenario_meta_payload["title"]
+                if "title" in scenario_data_payload:
+                    scenario.title = scenario_data_payload["title"]
                     fields_to_update.append("title")
-                if "description" in scenario_meta_payload:
-                    scenario.description = scenario_meta_payload["description"]
+                if "description" in scenario_data_payload:
+                    scenario.description = scenario_data_payload["description"]
                     fields_to_update.append("description")
-                if "is_active" in scenario_meta_payload:
-                    scenario.is_active = scenario_meta_payload["is_active"]
+                if "is_active" in scenario_data_payload:
+                    scenario.is_active = scenario_data_payload["is_active"]
                     fields_to_update.append("is_active")
                 if fields_to_update:
                     scenario.save(update_fields=fields_to_update)
 
             if scenario_rules is not serializers.empty:
                 ScenarioRule.objects.filter(scenario=scenario).delete()
-                rules_to_create = []
-                for rule_data in scenario_rules:
-                    rules_to_create.append(
-                        ScenarioRule(
-                            scenario=scenario,
-                            target_account=rule_data["target_account"],
-                            type=rule_data.get("type", RuleType.FIXED),
-                            amount=rule_data.get("amount"),
-                            order=rule_data.get("order", 0),
+                rules_to_create: list[ScenarioRule] = []
+                if scenario_rules:
+                    for rule_data in scenario_rules:
+                        rules_to_create.append(
+                            ScenarioRule(
+                                scenario=scenario,
+                                target_account=rule_data["target_account"],
+                                type=rule_data.get("type", RuleType.FIXED),
+                                amount=rule_data.get("amount"),
+                                order=rule_data.get("order", 0),
+                            )
                         )
-                    )
                 if rules_to_create:
                     ScenarioRule.objects.bulk_create(rules_to_create)
         else:

--- a/finance_planner/scenarios/urls.py
+++ b/finance_planner/scenarios/urls.py
@@ -1,1 +1,12 @@
-urlpatterns: list = []
+from django.urls import path
+
+from scenarios.views import ScenarioRuleCreateView
+
+
+urlpatterns = [
+    path(
+        "<uuid:scenario_id>/rules/",
+        ScenarioRuleCreateView.as_view(),
+        name="scenario-rule-create",
+    ),
+]

--- a/finance_planner/scenarios/views.py
+++ b/finance_planner/scenarios/views.py
@@ -1,1 +1,26 @@
-# write code here
+from django.shortcuts import get_object_or_404
+from rest_framework import generics, permissions
+
+from scenarios.models import PaymentScenario
+from scenarios.serializers import ScenarioRuleCreateSerializer
+
+
+class ScenarioRuleCreateView(generics.CreateAPIView):
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = ScenarioRuleCreateSerializer
+
+    def get_queryset(self):  # pragma: no cover - required by DRF generics
+        return PaymentScenario.objects.filter(user=self.request.user)
+
+    def get_scenario(self) -> PaymentScenario:
+        if not hasattr(self, "_scenario"):
+            self._scenario = get_object_or_404(
+                PaymentScenario.objects.filter(user=self.request.user),
+                pk=self.kwargs["scenario_id"],
+            )
+        return self._scenario
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["scenario"] = self.get_scenario()
+        return context

--- a/tests/regular_operations/conftest.py
+++ b/tests/regular_operations/conftest.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 from typing import Final
 
+import os
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+django.setup()
+
 from accounts.models import Account, AccountType
 from django.contrib.auth import get_user_model
 from django.urls import reverse

--- a/tests/scenarios/conftest.py
+++ b/tests/scenarios/conftest.py
@@ -1,0 +1,3 @@
+from tests.regular_operations.conftest import api_client, create_account, other_user, user
+
+__all__ = ["api_client", "create_account", "other_user", "user"]

--- a/tests/scenarios/test_scenario_rules_api.py
+++ b/tests/scenarios/test_scenario_rules_api.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+from accounts.models import AccountType
+from django.urls import reverse
+from django.utils import timezone
+import pytest
+from regular_operations.models import (
+    RegularOperation,
+    RegularOperationPeriodType,
+    RegularOperationType,
+)
+from rest_framework import status
+from scenarios.models import PaymentScenario
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_income_operation(user, to_account):
+    now = timezone.now()
+    return RegularOperation.objects.create(
+        user=user,
+        title="Зарплата",
+        description="Основной доход",
+        amount=Decimal("1000.00"),
+        type=RegularOperationType.INCOME,
+        to_account=to_account,
+        start_date=now,
+        end_date=now + timedelta(days=30),
+        period_type=RegularOperationPeriodType.MONTH,
+        period_interval=1,
+        is_active=True,
+    )
+
+
+def test_add_rule_to_scenario(api_client, user, create_account):
+    main_account = create_account(user, "Основной", AccountType.MAIN)
+    target_account = create_account(user, "Цели", AccountType.PURPOSE)
+    operation = _create_income_operation(user, main_account)
+    scenario = PaymentScenario.objects.create(
+        user=user,
+        operation=operation,
+        title="Распределение",
+        description="Сценарий по умолчанию",
+        is_active=True,
+    )
+
+    url = reverse("scenario-rule-create", kwargs={"scenario_id": scenario.id})
+    payload = {
+        "target_account": str(target_account.id),
+        "amount": "250.00",
+        "order": 1,
+    }
+
+    response = api_client.post(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    scenario.refresh_from_db()
+    rules = list(scenario.rules.all())
+    assert len(rules) == 1
+    assert rules[0].target_account_id == target_account.id
+    assert rules[0].amount == Decimal("250.00")
+    assert response.data["scenario_id"] == str(scenario.id)
+
+
+def test_add_rule_to_foreign_scenario_not_allowed(
+    api_client, user, other_user, create_account
+):
+    other_main = create_account(other_user, "Основной", AccountType.MAIN)
+    operation = _create_income_operation(other_user, other_main)
+    scenario = PaymentScenario.objects.create(
+        user=other_user,
+        operation=operation,
+        title="Их сценарий",
+        description="",  # noqa: PIE796
+        is_active=True,
+    )
+
+    url = reverse("scenario-rule-create", kwargs={"scenario_id": scenario.id})
+    target_account = create_account(user, "Цели", AccountType.PURPOSE)
+    payload = {
+        "target_account": str(target_account.id),
+        "amount": "100.00",
+        "order": 1,
+    }
+
+    response = api_client.post(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_add_rule_with_foreign_account_validation_error(
+    api_client, user, other_user, create_account
+):
+    main_account = create_account(user, "Основной", AccountType.MAIN)
+    operation = _create_income_operation(user, main_account)
+    scenario = PaymentScenario.objects.create(
+        user=user,
+        operation=operation,
+        title="Распределение",
+        description="",  # noqa: PIE796
+        is_active=True,
+    )
+    foreign_account = create_account(other_user, "Чужой счет", AccountType.RESERVE)
+
+    url = reverse("scenario-rule-create", kwargs={"scenario_id": scenario.id})
+    payload = {
+        "target_account": str(foreign_account.id),
+        "amount": "150.00",
+        "order": 1,
+    }
+
+    response = api_client.post(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "target_account" in response.data


### PR DESCRIPTION
## Summary
- ensure income operations create a default payment scenario when none is provided and keep manual updates scoped to supplied fields
- add an authenticated POST `/api/scenarios/<scenario_id>/rules/` endpoint for appending rules with account ownership validation
- extend API tests for default scenario creation and the new scenario rule endpoint, including test setup tweaks for Django configuration

## Testing
- DJANGO_SETTINGS_MODULE=core.settings pytest tests/regular_operations/test_regular_operations_api.py::test_create_income_operation_without_scenario_uses_defaults -q
- DJANGO_SETTINGS_MODULE=core.settings pytest tests/scenarios/test_scenario_rules_api.py -q

------
https://chatgpt.com/codex/tasks/task_e_68fdffe42fdc8332b54f85613e819cde