### PR TITLE
Add scenario management endpoints and tests

### DIFF
--- a/finance_planner/scenarios/urls.py
+++ b/finance_planner/scenarios/urls.py
@@ -1,11 +1,10 @@
-from django.urls import path
-from scenarios.views import ScenarioRuleCreateView
+from rest_framework.routers import SimpleRouter
+
+from scenarios.views import PaymentScenarioViewSet, ScenarioRuleViewSet
 
 
-urlpatterns = [
-    path(
-        "<uuid:scenario_id>/rules/",
-        ScenarioRuleCreateView.as_view(),
-        name="scenario-rule-create",
-    ),
-]
+router = SimpleRouter()
+router.register("rules", ScenarioRuleViewSet, basename="scenario-rule")
+router.register("", PaymentScenarioViewSet, basename="scenario")
+
+urlpatterns = router.urls

--- a/finance_planner/scenarios/views.py
+++ b/finance_planner/scenarios/views.py
@@ -1,25 +1,97 @@
-from django.shortcuts import get_object_or_404
-from rest_framework import generics, permissions
-from scenarios.models import PaymentScenario
-from scenarios.serializers import ScenarioRuleCreateSerializer
+from rest_framework import mixins, permissions, status, viewsets
+from rest_framework.response import Response
+
+from scenarios.models import PaymentScenario, ScenarioRule
+from scenarios.serializers import (
+    PaymentScenarioCreateSerializer,
+    PaymentScenarioSerializer,
+    PaymentScenarioUpdateSerializer,
+    ScenarioRuleCreateUpdateSerializer,
+    ScenarioRuleSerializer,
+)
 
 
-class ScenarioRuleCreateView(generics.CreateAPIView):
+class PaymentScenarioViewSet(
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
     permission_classes = [permissions.IsAuthenticated]
-    serializer_class = ScenarioRuleCreateSerializer
 
-    def get_queryset(self):  # pragma: no cover - required by DRF generics
-        return PaymentScenario.objects.filter(user=self.request.user)
+    def get_queryset(self):
+        return (
+            PaymentScenario.objects.filter(user=self.request.user)
+            .select_related("operation")
+            .prefetch_related("rules", "rules__target_account")
+        )
 
-    def get_scenario(self) -> PaymentScenario:
-        if not hasattr(self, "_scenario"):
-            self._scenario = get_object_or_404(
-                PaymentScenario.objects.filter(user=self.request.user),
-                pk=self.kwargs["scenario_id"],
-            )
-        return self._scenario
+    def get_serializer_class(self):
+        if self.action == "create":
+            return PaymentScenarioCreateSerializer
+        if self.action in {"update", "partial_update"}:
+            return PaymentScenarioUpdateSerializer
+        return PaymentScenarioSerializer
 
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        context["scenario"] = self.get_scenario()
-        return context
+    def _serialize_response(self, instance, *, status_code):
+        serializer = PaymentScenarioSerializer(instance, context=self.get_serializer_context())
+        return Response(serializer.data, status=status_code)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        scenario = serializer.save()
+        return self._serialize_response(scenario, status_code=status.HTTP_201_CREATED)
+
+    def update(self, request, *args, **kwargs):  # pragma: no cover - handled by partial_update
+        return super().update(request, *args, **kwargs)
+
+    def partial_update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        scenario = serializer.save()
+        return self._serialize_response(scenario, status_code=status.HTTP_200_OK)
+
+
+class ScenarioRuleViewSet(
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        return (
+            ScenarioRule.objects.filter(scenario__user=self.request.user)
+            .select_related("scenario", "target_account")
+            .order_by("order")
+        )
+
+    def get_serializer_class(self):
+        if self.action in {"create", "update", "partial_update"}:
+            return ScenarioRuleCreateUpdateSerializer
+    
+        return ScenarioRuleSerializer
+
+    def _serialize_response(self, instance, *, status_code):
+        serializer = ScenarioRuleSerializer(instance, context=self.get_serializer_context())
+        return Response(serializer.data, status=status_code)
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        rule = serializer.save()
+        return self._serialize_response(rule, status_code=status.HTTP_201_CREATED)
+
+    def partial_update(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        rule = serializer.save()
+        return self._serialize_response(rule, status_code=status.HTTP_200_OK)

--- a/tests/scenarios/test_scenarios_api.py
+++ b/tests/scenarios/test_scenarios_api.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+from accounts.models import AccountType
+from django.urls import reverse
+from django.utils import timezone
+import pytest
+
+from regular_operations.models import (
+    RegularOperation,
+    RegularOperationPeriodType,
+    RegularOperationType,
+)
+from rest_framework import status
+from scenarios.models import PaymentScenario
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_income_operation(user, to_account):
+    now = timezone.now()
+    return RegularOperation.objects.create(
+        user=user,
+        title="Зарплата",
+        description="Основной доход",
+        amount=Decimal("1000.00"),
+        type=RegularOperationType.INCOME,
+        to_account=to_account,
+        start_date=now,
+        end_date=now + timedelta(days=30),
+        period_type=RegularOperationPeriodType.MONTH,
+        period_interval=1,
+        is_active=True,
+    )
+
+
+def test_create_scenario_for_operation(api_client, user, create_account):
+    main_account = create_account(user, "Основной", AccountType.MAIN)
+    operation = _create_income_operation(user, main_account)
+
+    url = reverse("scenario-list")
+    payload = {
+        "operation_id": str(operation.id),
+        "title": "План распределения",
+        "description": "Отдельный сценарий",
+        "is_active": False,
+    }
+
+    response = api_client.post(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    scenario = PaymentScenario.objects.get(operation=operation)
+    assert scenario.title == payload["title"]
+    assert response.data["operation_id"] == str(operation.id)
+    assert response.data["rules"] == []
+
+
+def test_update_scenario(api_client, user, create_account):
+    main_account = create_account(user, "Основной", AccountType.MAIN)
+    operation = _create_income_operation(user, main_account)
+    scenario = PaymentScenario.objects.create(
+        user=user,
+        operation=operation,
+        title="Старое название",
+        description="",
+        is_active=True,
+    )
+
+    url = reverse("scenario-detail", args=[scenario.id])
+    payload = {"title": "Новое название", "description": "Обновлённое описание"}
+
+    response = api_client.patch(url, payload, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    scenario.refresh_from_db()
+    assert scenario.title == payload["title"]
+    assert scenario.description == payload["description"]
+    assert response.data["title"] == payload["title"]
+
+
+def test_retrieve_scenario_includes_rules(api_client, user, create_account):
+    main_account = create_account(user, "Основной", AccountType.MAIN)
+    target_account = create_account(user, "Цели", AccountType.PURPOSE)
+    operation = _create_income_operation(user, main_account)
+    scenario = PaymentScenario.objects.create(
+        user=user,
+        operation=operation,
+        title="Распределение",
+        description="",
+        is_active=True,
+    )
+    scenario.rules.create(target_account=target_account, amount=Decimal("150.00"), order=1)
+
+    url = reverse("scenario-detail", args=[scenario.id])
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["rules"]) == 1
+    assert response.data["rules"][0]["target_account_id"] == str(target_account.id)


### PR DESCRIPTION
## Summary
- add viewsets and serializers for payment scenarios and scenario rules, including ownership validation and response formatting
- expose the new endpoints in the scenarios router and cover scenario CRUD plus rule lifecycle with dedicated tests
- update regular operation API tests to use the new scenario workflow and expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6905057c796083329e2270d2a5bdf350