### PR TITLE
Add dev bootstrap utilities for dev database

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from core.bootstrap import bootstrap_dev_data
+
+
+@pytest.fixture(scope="session")
+def bootstrap_db(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        bootstrap_dev_data()
+    yield
+
+
+@pytest.fixture(scope="function")
+def fresh_db(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        bootstrap_dev_data()
+    yield

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import os
+
+import django
 import pytest
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "core.settings")
+django.setup()
 
 from core.bootstrap import bootstrap_dev_data
 

--- a/finance_planner/core/management/__init__.py
+++ b/finance_planner/core/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management package for core app."""

--- a/finance_planner/core/management/commands/__init__.py
+++ b/finance_planner/core/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for core app."""

--- a/finance_planner/core/management/commands/bootstrap_dev_data.py
+++ b/finance_planner/core/management/commands/bootstrap_dev_data.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+
+from core.bootstrap import bootstrap_dev_data
+
+
+class Command(BaseCommand):
+    help = "Flushes the database and loads development bootstrap data."
+
+    def handle(self, *args, **options):
+        bootstrap_dev_data()
+        self.stdout.write("Database bootstrapped successfully")

--- a/finance_planner/core/settings.py
+++ b/finance_planner/core/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
     "drf_yasg",
     "corsheaders",
     # Local apps
+    "core",
     "users",
     "accounts",
     "transactions",

--- a/tests/accounts/test_account_statistics.py
+++ b/tests/accounts/test_account_statistics.py
@@ -1,19 +1,14 @@
 from datetime import timedelta
-from decimal import Decimal
 
 from freezegun import freeze_time
 import pytest
-from regular_operations.models import (
-    RegularOperation,
-    RegularOperationPeriodType,
-    RegularOperationType,
-)
+from regular_operations.models import RegularOperation, RegularOperationType
 from rest_framework import status
+from rest_framework.test import APIClient
 from scenarios.models import Scenario
 
 from tests.constants import (
     DEFAULT_TIME,
-    DEFAULT_TIME_WITH_OFFSET,
     MAIN_ACCOUNT_UUID,
     SECOND_ACCOUNT_UUID,
     THIRD_ACCOUNT_UUID,
@@ -24,14 +19,7 @@ pytestmark = pytest.mark.django_db
 
 
 @freeze_time(DEFAULT_TIME)
-def test_statistics_returns_daily_balances_from_db_truth(
-    api_client,
-    main_user,
-    create_account,
-    main_account,
-    second_account,
-    third_account,
-):
+def test_statistics_returns_daily_balances_from_db_truth(fresh_db, bootstrap_owner):
     """
     Готовим данные так же, как в тесте calculate:
       - Основной счёт + два целевых (Накопления, Ипотека)
@@ -46,98 +34,36 @@ def test_statistics_returns_daily_balances_from_db_truth(
     start_date = DEFAULT_TIME.date()
     end_date = start_date + timedelta(days=2)
 
-    # Делаем операции дневными
-    period_type = RegularOperationPeriodType.DAY
-    period_interval = 1
+    income_operations = RegularOperation.objects.filter(
+        type=RegularOperationType.INCOME
+    ).order_by("title")
+    assert income_operations.count() == 2
 
-    # --- Регулярные операции: доходы
-    income_1 = RegularOperation.objects.create(
-        user=main_user,
-        title="Зарплата",
-        description="Основной доход",
-        amount=Decimal("1000.00"),
-        type=RegularOperationType.INCOME,
-        to_account=main_account,
-        start_date=DEFAULT_TIME,
-        end_date=DEFAULT_TIME_WITH_OFFSET,
-        period_type=period_type,
-        period_interval=period_interval,
-        is_active=True,
-    )
-    income_2 = RegularOperation.objects.create(
-        user=main_user,
-        title="Фриланс",
-        description="Доп. доход",
-        amount=Decimal("500.00"),
-        type=RegularOperationType.INCOME,
-        to_account=main_account,
-        start_date=DEFAULT_TIME,
-        end_date=DEFAULT_TIME_WITH_OFFSET,
-        period_type=period_type,
-        period_interval=period_interval,
-        is_active=True,
-    )
+    expense_operations = RegularOperation.objects.filter(
+        type=RegularOperationType.EXPENSE
+    ).order_by("title")
+    assert expense_operations.count() == 2
 
-    # --- Регулярные операции: расходы
-    RegularOperation.objects.create(
-        user=main_user,
-        title="Повседневные траты",
-        description="",
-        amount=Decimal("100.00"),
-        type=RegularOperationType.EXPENSE,
-        from_account=main_account,
-        start_date=DEFAULT_TIME,
-        end_date=DEFAULT_TIME_WITH_OFFSET,
-        period_type=period_type,
-        period_interval=period_interval,
-        is_active=True,
-    )
-    RegularOperation.objects.create(
-        user=main_user,
-        title="Питание",
-        description="",
-        amount=Decimal("50.00"),
-        type=RegularOperationType.EXPENSE,
-        from_account=main_account,
-        start_date=DEFAULT_TIME,
-        end_date=DEFAULT_TIME_WITH_OFFSET,
-        period_type=period_type,
-        period_interval=period_interval,
-        is_active=True,
-    )
-
-    # --- Сценарии и правила
-    scenario_1 = Scenario.objects.create(
-        user=main_user,
-        operation=income_1,
-        title="Распределение зарплаты",
-        description="",
-        is_active=True,
-    )
-    scenario_1.rules.create(target_account=second_account, amount=Decimal("200.00"), order=1)
-    scenario_1.rules.create(target_account=third_account, amount=Decimal("300.00"), order=2)
-
-    scenario_2 = Scenario.objects.create(
-        user=main_user,
-        operation=income_2,
-        title="Распределение фриланса",
-        description="",
-        is_active=True,
-    )
-    scenario_2.rules.create(target_account=second_account, amount=Decimal("100.00"), order=1)
+    scenarios = Scenario.objects.filter(operation__in=income_operations).order_by("title")
+    assert scenarios.count() == 2
 
     calc_payload = {
         "start_date": start_date.isoformat(),
         "end_date": end_date.isoformat(),
     }
-    calc_resp = api_client.post("/api/transactions/calculate/", calc_payload, format="json")
+    client = APIClient()
+    client.force_authenticate(user=bootstrap_owner)
+
+    calc_resp = client.post(
+        "/api/transactions/calculate/", calc_payload, format="json"
+    )
     assert calc_resp.status_code == status.HTTP_200_OK, calc_resp.data
 
     statistics_payload = {
         "start_date": start_date.isoformat(),
         "end_date": end_date.isoformat(),
     }
-    statistics_response = api_client.post(
+    statistics_response = client.post(
         "/api/accounts/statistics/", statistics_payload, format="json"
     )
     assert statistics_response.status_code == status.HTTP_200_OK, statistics_response.data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,13 @@ def third_account(main_user):
 
 
 @pytest.fixture
+def bootstrap_owner(bootstrap_db):
+    return get_user_model().objects.get(username="owner")
+
+
+
+
+@pytest.fixture
 def other_account(other_user):
     return Account.objects.create(
         id=OTHER_ACCOUNT_UUID, user=other_user, name="Резерв", type=AccountType.RESERVE

--- a/tests/test_bootstrap_fixtures.py
+++ b/tests/test_bootstrap_fixtures.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from accounts.models import Account
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_bootstrap_db_creates_superuser(bootstrap_db):
+    assert get_user_model().objects.filter(is_superuser=True).count() == 1
+
+
+def test_fresh_db_provides_accounts(fresh_db):
+    assert Account.objects.count() == 3
+    Account.objects.first().delete()
+
+
+def test_fresh_db_resets_state_between_tests(fresh_db):
+    assert Account.objects.count() == 3


### PR DESCRIPTION
## Summary
- add a transactional `bootstrap_dev_data` helper that seeds dev data via the public API and expose it through a management command
- register the core app so the command is discoverable and add pytest fixtures plus sample tests demonstrating their usage

## Testing
- uv run python finance_planner/manage.py bootstrap_dev_data
- uv run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691230fa21888332a9df7096678215c5)